### PR TITLE
Move dependency versions to a version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath "org.quiltmc.unpick:unpick:${project.unpick_version}"
-		classpath "org.quiltmc.unpick:unpick-format-utils:${project.unpick_version}"
+		classpath(libs.unpick)
+		classpath(libs.unpick.format.utils)
 	}
 }
 
@@ -72,13 +72,13 @@ configurations {
 }
 
 dependencies {
-	enigmaRuntime "cuchaz:enigma-swing:${project.enigma}"
-	enigmaRuntime "org.quiltmc:quilt-enigma-plugin:${project.enigma_plugin}"
-	javadocClasspath "net.fabricmc:fabric-loader:${project.fabric_loader}"
-	javadocClasspath "org.jetbrains:annotations:${project.jetbrains_annotations}"
-	javadocClasspath "com.google.code.findbugs:jsr305:${project.jsr305}" // for some other jsr annotations
-	decompileClasspath "net.fabricmc:cfr:${project.cfr}"
-	unpick "org.quiltmc.unpick:unpick-cli:${project.unpick_version}"
+	enigmaRuntime(libs.enigma.swing)
+	enigmaRuntime(libs.enigma.plugin)
+	javadocClasspath(libs.fabric.loader)
+	javadocClasspath(libs.jetbrains.annotations)
+	javadocClasspath(libs.jsr305) // for some other jsr annotations
+	decompileClasspath(libs.cfr)
+	unpick(libs.unpick.cli)
 	hashed "org.quiltmc:hashed:${minecraft_version}${USE_SNAPSHOT_HASHES ? "-SNAPSHOT" : ""}"
 	intermediary "net.fabricmc:intermediary:${minecraft_version}:v2"
 }
@@ -321,20 +321,20 @@ javadoc {
 
 		addBooleanOption "-allow-script-in-comments", true
 		links(
-				"https://guava.dev/releases/${project.guava}/api/docs/",
-				"https://www.javadoc.io/doc/com.google.code.gson/gson/${project.gson}/",
+				"https://guava.dev/releases/${libs.versions.guava.get()}/api/docs/",
+				"https://javadoc.io/doc/com.google.code.gson/gson/${project.gson}/",
 				'https://logging.apache.org/log4j/2.x/log4j-api/apidocs/',
-				"https://javadoc.io/doc/org.jetbrains/annotations/${project.jetbrains_annotations}/",
-				"https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/${project.jsr305}/",
+				"https://javadoc.io/doc/org.jetbrains/annotations/${libs.versions.jetbrains.annotations.get()}/",
+				"https://javadoc.io/doc/com.google.code.findbugs/jsr305/${libs.versions.jsr305.get()}/",
 				'https://javadoc.lwjgl.org/',
 				'https://fastutil.di.unimi.it/docs/',
 				"https://netty.io/${project.netty}/api/",
-				"https://commons.apache.org/proper/commons-logging/javadocs/api-${project.commons_logging}/",
-				"https://commons.apache.org/proper/commons-lang/javadocs/api-${project.commons_lang}/",
-				"https://commons.apache.org/proper/commons-io/javadocs/api-${project.commons_io}/",
+				"https://commons.apache.org/proper/commons-logging/javadocs/api-release/",
+				"https://commons.apache.org/proper/commons-lang/javadocs/api-release/",
+				"https://commons.apache.org/proper/commons-io/apidocs/",
 				"https://commons.apache.org/proper/commons-codec/archives/${project.commons_codec}/apidocs/",
 				"https://javadoc.io/doc/org.apache.commons/commons-compress/${project.commons_compress}/",
-				"https://maven.fabricmc.net/docs/fabric-loader-${project.fabric_loader}/",
+				"https://maven.fabricmc.net/docs/fabric-loader-${libs.versions.fabric.loader.get()}/",
 				"https://docs.oracle.com/en/java/javase/${project.java}/docs/api/"
 		)
 		// https://docs.oracle.com/en/java/javase/17/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -24,25 +24,26 @@ repositories {
 }
 
 dependencies {
-	implementation("commons-io:commons-io:${project.commons_io}")
-	implementation("de.undercouch:gradle-download-task:${project.gradle_download}")
-	implementation("net.fabricmc:stitch:${project.stitch}")
-	implementation("org.quiltmc:quilt-enigma-plugin:${project.enigma_plugin}")
-	implementation("org.quiltmc:tiny-remapper:${project.tiny_remapper}")
-	implementation("org.quiltmc:launchermeta-parser:${project.launchermeta_parser}")
-	implementation("com.google.guava:guava:${project.guava}")
-	implementation("cuchaz:enigma-cli:${project.enigma}")
-	implementation("cuchaz:enigma:${project.enigma}")
-	implementation("org.quiltmc.unpick:unpick:${project.unpick_version}")
-	implementation("org.quiltmc.unpick:unpick-format-utils:${project.unpick_version}")
-	implementation("org.quiltmc.unpick:unpick-cli:${project.unpick_version}")
-	implementation("net.fabricmc:mapping-io:${project.mapping_io}")
-	implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${project.jackson_dataformat}")
-	implementation("org.quiltmc:javadoc-draftsman:${project.javadoc_draftsman}")
+	implementation(libs.commons.io)
+	implementation(libs.download.task)
+	implementation(libs.guava)
+	implementation(libs.jackson.xml)
+	implementation(libs.launchermeta.parser)
+
+	implementation(libs.enigma)
+	implementation(libs.enigma.cli)
+	implementation(libs.enigma.plugin)
+	implementation(libs.tiny.remapper)
+	implementation(libs.stitch)
+	implementation(libs.unpick)
+	implementation(libs.unpick.cli)
+	implementation(libs.unpick.format.utils)
+	implementation(libs.mapping.io)
+	implementation(libs.javadoc.draftsman)
 
 	// Decompilers
-	implementation("net.fabricmc:cfr:${project.cfr}")
-	implementation("org.quiltmc:quiltflower:${project.quiltflower}")
+	implementation(libs.cfr)
+	implementation(libs.quiltflower)
 }
 
 gradlePlugin {

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,25 +1,2 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
-
-# Fabric & Quilt Libraries
-enigma=1.2.1
-enigma_plugin=1.2.1
-launchermeta_parser=1.0.0
-mapping_io=0.3.0
-quiltflower=1.9.0
-stitch=0.6.1
-tiny_remapper=0.7.2
-
-# Javadoc generation/linking
-fabric_loader=0.14.10
-jetbrains_annotations=23.0.0
-mapping_poet=0.3.0
-
-# Other Libraries
-cfr=0.2.0
-commons_io=2.11.0
-gradle_download=4.1.1
-guava=31.1-jre
-jackson_dataformat=2.13.4
-javadoc_draftsman=1.2.1
-unpick_version=3.0.1-SNAPSHOT

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+	versionCatalogs {
+		libs {
+			from(files("../gradle/libs.versions.toml"))
+		}
+	}
+}

--- a/buildSrc/src/main/java/quilt/internal/tasks/MappingsTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/MappingsTask.java
@@ -1,6 +1,8 @@
 package quilt.internal.tasks;
 
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.VersionCatalog;
+import org.gradle.api.artifacts.VersionCatalogsExtension;
 import quilt.internal.MappingsExtension;
 import quilt.internal.MappingsPlugin;
 import quilt.internal.util.DownloadImmediate;
@@ -25,5 +27,13 @@ public interface MappingsTask extends Task {
 
     default MappingsExtension mappingsExt() {
         return MappingsPlugin.getExtension(getProject());
+    }
+
+    default VersionCatalogsExtension versionCatalogs() {
+        return getProject().getExtensions().getByType(VersionCatalogsExtension.class);
+    }
+
+    default VersionCatalog libs() {
+        return versionCatalogs().named("libs");
     }
 }

--- a/buildSrc/src/main/java/quilt/internal/tasks/build/MappingsV2JarTask.java
+++ b/buildSrc/src/main/java/quilt/internal/tasks/build/MappingsV2JarTask.java
@@ -3,6 +3,7 @@ package quilt.internal.tasks.build;
 import java.io.File;
 import java.util.Map;
 
+import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.jvm.tasks.Jar;
@@ -20,8 +21,9 @@ public class MappingsV2JarTask extends Jar implements MappingsTask {
         getDestinationDirectory().set(getProject().file("build/libs"));
 
         File unpickMetaFile = mappingsExt().getFileConstants().unpickMeta;
+        String version = libs().findVersion("unpick").map(VersionConstraint::getRequiredVersion).orElseThrow(() -> new RuntimeException("Could not find unpick version"));
         from(unpickMetaFile, copySpec -> {
-            copySpec.expand(Map.of("version", getProject().property("unpick_version")));
+            copySpec.expand(Map.of("version", version));
             copySpec.rename(unpickMetaFile.getName(), "extras/unpick.json");
         });
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,27 +1,11 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-# Fabric & Quilt Libraries
-enigma=1.2.1
-enigma_plugin=1.2.1
-quiltflower=1.9.0
-stitch=0.6.1
-unpick_version=3.0.1-SNAPSHOT
+# Modify versions in gradle/libs.versions.toml
 
-# Javadoc generation/linking
-fabric_loader=0.14.10
-jetbrains_annotations=23.0.0
-jsr305=3.0.2
-mapping_poet=0.3.0
-
-# Other Libraries
-cfr=0.2.0
+# Javadoc linking
 commons_codec=1.15
 commons_compress=1.21
-commons_lang=3.10
-commons_logging=1.1.3
-commons_io=2.7
-guava=31.1-jre
 gson=2.9.1
 java=17
 netty=4.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,49 @@
+[versions]
+commons-io = "2.11.0"
+download-task = "4.1.1"
+guava = "31.1-jre"
+jackson-xml = "2.13.4"
+launchermeta-parser = "1.0.0"
+enigma = "1.2.1"
+enigma-plugin = "1.2.1"
+tiny-remapper = "0.7.2"
+stitch = "0.6.1"
+unpick = "3.0.1-SNAPSHOT"
+mapping-io = "0.3.0"
+javadoc-draftsman = "1.2.1"
+
+fabric-loader = "0.14.10"
+jetbrains-annotations = "23.0.0"
+jsr305 = "3.0.2"
+gson = "2.9.1"
+netty = "4.1"
+
+quiltflower = "1.9.0"
+cfr = "0.2.0"
+
+[libraries]
+commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
+download-task = { module = "de.undercouch:gradle-download-task", version.ref = "download-task" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+jackson-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson-xml" }
+launchermeta-parser = { module = "org.quiltmc:launchermeta-parser", version.ref = "launchermeta-parser" }
+
+enigma = { module = "cuchaz:enigma", version.ref = "enigma" }
+enigma-cli = { module = "cuchaz:enigma-cli", version.ref = "enigma" }
+enigma-swing = { module = "cuchaz:enigma-swing", version.ref = "enigma" }
+enigma-plugin = { module = "org.quiltmc:quilt-enigma-plugin", version.ref = "enigma-plugin" }
+tiny-remapper = { module = "org.quiltmc:tiny-remapper", version.ref = "tiny-remapper" }
+stitch = { module = "net.fabricmc:stitch", version.ref = "stitch" }
+unpick = { module = "org.quiltmc.unpick:unpick", version.ref = "unpick" }
+unpick-cli = { module = "org.quiltmc.unpick:unpick-cli", version.ref = "unpick" }
+unpick-format-utils = { module = "org.quiltmc.unpick:unpick-format-utils", version.ref = "unpick" }
+mapping-io = { module = "net.fabricmc:mapping-io", version.ref = "mapping-io" }
+javadoc-draftsman = { module = "org.quiltmc:javadoc-draftsman", version.ref = "javadoc-draftsman" }
+
+fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabric-loader" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
+jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
+
+# Decompilers
+cfr = { module = "net.fabricmc:cfr", version.ref = "cfr" }
+quiltflower = { module = "org.quiltmc:quiltflower", version.ref = "quiltflower" }


### PR DESCRIPTION
Keep the ones used only for javadoc linking